### PR TITLE
Make user create noop when no queue specified

### DIFF
--- a/elisctl/user/create.py
+++ b/elisctl/user/create.py
@@ -34,7 +34,7 @@ def create_command(username: str, password: str, queues: List[str], group: str) 
         if len(organizations) > 1:
             raise click.ClickException(f"User can be in only 1 organization.")
         elif not organizations:
-            raise click.ClickException(f"User must be in at least 1 organization.")
+            return
         else:
             organization_url = organizations.pop()
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -9,16 +9,17 @@ from requests_mock.response import _Context
 from tests.conftest import API_URL, TOKEN, match_uploaded_json
 from elisctl.user.create import create_command
 
+USERNAME = "test_user@rossum.ai"
+PASSWORD = "secret"
 
+
+@pytest.mark.runner_setup(
+    env={"ELIS_URL": API_URL, "ELIS_USERNAME": USERNAME, "ELIS_PASSWORD": PASSWORD}
+)
+@pytest.mark.usefixtures("mock_login_request")
 class TestUser:
-    USERNAME = "test_user@rossum.ai"
-    PASSWORD = "secret"
     QUEUES = ["1", "2"]
 
-    @pytest.mark.runner_setup(
-        env={"ELIS_URL": API_URL, "ELIS_USERNAME": USERNAME, "ELIS_PASSWORD": PASSWORD}
-    )
-    @pytest.mark.usefixtures("mock_login_request")
     def test_create(self, requests_mock, cli_runner):
         queues_url = f"{API_URL}/v1/queues"
         workspaces_url = f"{API_URL}/v1/workspaces"
@@ -49,10 +50,10 @@ class TestUser:
             additional_matcher=partial(
                 match_uploaded_json,
                 {
-                    "username": self.USERNAME,
-                    "email": self.USERNAME,
+                    "username": USERNAME,
+                    "email": USERNAME,
                     "organization": organization_url,
-                    "password": self.PASSWORD,
+                    "password": PASSWORD,
                     "groups": [f"{groups_url}/1"],
                     "queues": [f"{queues_url}/{q_id}" for q_id in self.QUEUES],
                 },
@@ -60,7 +61,11 @@ class TestUser:
             request_headers={"Authorization": f"Token {TOKEN}"},
             status_code=201,
         )
-        result = cli_runner.invoke(create_command, [self.USERNAME, self.PASSWORD, *self.QUEUES])
+        result = cli_runner.invoke(create_command, [USERNAME, PASSWORD, *self.QUEUES])
+        assert not result.exit_code, print_tb(result.exc_info[2])
+
+    def test_create_noop_without_queues(self, cli_runner):
+        result = cli_runner.invoke(create_command, [USERNAME, PASSWORD])
         assert not result.exit_code, print_tb(result.exc_info[2])
 
 


### PR DESCRIPTION
Fixes: https://github.com/rossumai/elisctl/issues/5

At the first glance, the queues should be required argument, however, the reasoning in [click documentation](http://click.palletsprojects.com/en/7.x/arguments/#variadic-arguments) discourages such behaviour. Thus `elisctl user create USERNAME PASSWORD` will result in noop.