### PR TITLE
elisctl user create: Make passing the -q list required

### DIFF
--- a/elisctl/user/create.py
+++ b/elisctl/user/create.py
@@ -12,7 +12,7 @@ from elisctl.user.options import group_option, locale_option, queue_option, pass
 @click.command(name="create", short_help="Create user.")
 @click.argument("username")
 @password_option
-@queue_option
+@queue_option(required=True)
 @click.option("-o", "--organization-id", type=int, help="Organization ID.", hidden=True)
 @group_option
 @locale_option
@@ -31,18 +31,7 @@ def create_command(
     with APIClient() as api:
         _check_user_does_not_exists(api, username)
         organization_dict = _get_organization(api, organization_id)
-
-        workspace_urls = {
-            w["url"]
-            for w in get_json(api.get("workspaces", {"organization": organization_dict["id"]}))[
-                "results"
-            ]
-        }
-        queue_urls = []
-        for queue in queue_id:
-            queue_dict = get_json(api.get(f"queues/{queue}"))
-            if queue_dict["workspace"] in workspace_urls:
-                queue_urls.append(queue_dict["url"])
+        queue_urls = [get_json(api.get(f"queues/{queue}"))["url"] for queue in queue_id]
 
         response = api.post(
             "users",

--- a/elisctl/user/options.py
+++ b/elisctl/user/options.py
@@ -31,13 +31,13 @@ def locale_option(command: Optional[Callable] = None, **kwargs):
     return decorator(command)
 
 
-queue_option = click.option(
-    "-q",
-    "--queue-id",
-    type=int,
-    multiple=True,
-    help="Queue IDs, which the user will be associated with.",
-)
+def queue_option(command: Optional[Callable] = None, **kwargs):
+    default_kwargs = {"type": int, "multiple": True, "help": "Queue IDs accessible by the user."}
+    kwargs = {**default_kwargs, **kwargs}
+    decorator = click.option("-q", "--queue-id", **kwargs)
+    if command is None:
+        return decorator
+    return decorator(command)
 
 
 def password_option(command: Optional[Callable] = None, **kwargs):


### PR DESCRIPTION
The default behavior of creating users with no queue access would almost never produce useful behavior for endusers.