### PR TITLE
installer.cfg: Add missing tabulate package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       install:
         - sudo apt-get update
         - sudo apt-get -y install nsis
-        - pip install pynsist
+        - pip install pynsist tabulate jsondiff
       script: pynsist installer.cfg
       deploy:
         provider: releases

--- a/elisctl/tools/compare.py
+++ b/elisctl/tools/compare.py
@@ -1,22 +1,16 @@
 #!/usr/bin/env python3
 import difflib
 import json
-import platform
 import pprint
 
 import click
 import re
+from jsondiff import diff as json_diff, JsonDumper
 from typing import Iterable, IO
 
+from elisctl.lib import split_dict_params
+
 DIFF_TYPES = ["jsondiff", "difflib"]
-
-if platform.system() == "Windows":
-    DIFF_TYPES.remove("jsondiff")
-else:
-    from jsondiff import diff as json_diff, JsonDumper
-
-from elisctl.lib import split_dict_params  # noqa: E402
-
 DIFF_RE = re.compile(r"^[+-^]")
 
 

--- a/installer.cfg
+++ b/installer.cfg
@@ -23,6 +23,8 @@ pypi_wheels = certifi==2018.11.29
     six==1.12.0
     urllib3==1.24.1
     xlrd==1.2.0
+packages = tabulate
+    jsondiff
 
 files = LICENSE
     README.md


### PR DESCRIPTION
Honestly, I'm not sure if travis is going to work with tabulate specified like this, but it seems that it doesn't provide a wheel in pypi, which gives pynsis some trouble...