### PR TITLE
Use configparser without interpolation to allow special characters

### DIFF
--- a/elisctl/configure.py
+++ b/elisctl/configure.py
@@ -21,7 +21,7 @@ ELIS_PASSWORD: password to the ELIS account
 
 @click.command(name="configure", help=HELP)
 def cli():
-    config = configparser.ConfigParser()
+    config = configparser.RawConfigParser()
     config["default"] = {
         "url": click.prompt(f"API URL", default=DEFAULT_ELIS_URL, type=str).strip().rstrip("/"),
         "username": click.prompt(f"Username", type=str).strip(),
@@ -37,7 +37,7 @@ def get_credential(attr: str) -> str:
     if res is not None:
         return res
 
-    config = configparser.ConfigParser()
+    config = configparser.RawConfigParser()
     config.read(CONFIGURATION_PATH)
     try:
         config_dict = config["default"]

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -14,7 +14,7 @@ class TestConfigure:
         expected_credentials = {
             "url": "mock://some.example.com",
             "username": "some_username",
-            "password": "secret",
+            "password": "secret%",
         }
         result = isolated_cli_runner.invoke(
             configure.cli,
@@ -28,7 +28,7 @@ class TestConfigure:
         )
         assert not result.exit_code, print_tb(result.exc_info[2])
 
-        config = configparser.ConfigParser()
+        config = configparser.RawConfigParser()
         config.read(configuration_path)
 
         assert expected_credentials == config["default"]
@@ -43,13 +43,13 @@ class TestConfigure:
         with isolated_cli_runner.isolation():
             configuration_path.parent.mkdir()
 
-            config = configparser.ConfigParser()
-            config["default"] = {"test": "test"}
+            config = configparser.RawConfigParser()
+            config["default"] = {"test": "test%"}
             with configuration_path.open("w") as f:
                 config.write(f)
 
             result = configure.get_credential("test")
-        assert "test" == result
+        assert "test%" == result
 
     @pytest.mark.usefixtures("configuration_path")
     def test_no_credentials(self):


### PR DESCRIPTION
Fixes: https://github.com/rossumai/elisctl/issues/34