### PR TITLE
Use utf8 for output file when downloading schema

### DIFF
--- a/elisctl/schema/__init__.py
+++ b/elisctl/schema/__init__.py
@@ -22,7 +22,7 @@ cli.add_command(upload.upload_command)
 @click.argument("id_", metavar="ID", type=str)
 @click.option("--indent", default=2, type=int)
 @click.option("--ensure-ascii", is_flag=True, type=bool)
-@click.option("-O", "--output-file", type=click.File("w"))
+@click.option("-O", "--output-file", type=click.File("w", encoding="utf-8"))
 def download_command(
     ctx: click.Context, id_: str, indent: int, ensure_ascii: bool, output_file: Optional[IO[str]]
 ):

--- a/elisctl/schema/__init__.py
+++ b/elisctl/schema/__init__.py
@@ -31,7 +31,4 @@ def download_command(
     schema_json = json.dumps(
         schema_dict["content"], indent=indent, ensure_ascii=ensure_ascii, sort_keys=True
     )
-    if output_file:
-        print(schema_json, file=output_file)
-    else:
-        click.echo(schema_json)
+    click.echo(schema_json, file=output_file)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,11 +1,8 @@
-import json
-import re
 from traceback import print_tb
 
 import pytest
+import re
 
-from tests.conftest import API_URL
-from elisctl.schema import download_command as download_schema
 from elisctl.csv import download_command as download_csv
 
 DATA = """\
@@ -28,15 +25,3 @@ class TestDownload:
         assert not result.exit_code, print_tb(result.exc_info[2])
         assert 1 == len(requests_mock.request_history)
         assert DATA == result.stdout.strip()
-
-    @pytest.mark.runner_setup(
-        env={"ELIS_URL": API_URL, "ELIS_USERNAME": USERNAME, "ELIS_PASSWORD": PASSWORD}
-    )
-    @pytest.mark.usefixtures("mock_login_request", "mock_get_schema")
-    def test_schema(self, cli_runner):
-        schema_id = "1"
-        schema_content = []
-
-        result = cli_runner.invoke(download_schema, [schema_id])
-        assert not result.exit_code, print_tb(result.exc_info[2])
-        assert schema_content == json.loads(result.stdout)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -206,6 +206,7 @@ USERNAME = "test_user@rossum.ai"
 PASSWORD = "secret"
 
 schema_id = "1"
+schema_content = [{"label": "Příliš žluťoučký kůň úpěl ďábelské ódy."}]
 
 
 @pytest.mark.runner_setup(
@@ -218,11 +219,11 @@ class TestDownload:
     def test_stdout(self, cli_runner):
         result = cli_runner.invoke(download_command, [schema_id])
         assert not result.exit_code, print_tb(result.exc_info[2])
-        assert [] == json.loads(result.stdout)
+        assert schema_content == json.loads(result.stdout)
 
     def test_output_file(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
             download_command, [schema_id, "-O", str(self.output_file)]
         )
         assert not result.exit_code, print_tb(result.exc_info[2])
-        assert [] == json.loads(self.output_file.read_text())
+        assert schema_content == json.loads(self.output_file.read_text())

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,8 @@ from traceback import print_tb
 
 import pytest
 
-from elisctl.schema import transform
+from elisctl.schema import transform, download_command
+from tests.conftest import API_URL
 
 SCHEMA_NAME = "schema.json"
 OPTIONS_NAME = "options.json"
@@ -198,3 +199,20 @@ def _original_schema_file(isolated_cli_runner):
     with open(SCHEMA_NAME, "w") as schema:
         json.dump(ORIGINAL_SCHEMA, schema)
     yield
+
+
+USERNAME = "test_user@rossum.ai"
+PASSWORD = "secret"
+
+schema_id = "1"
+
+
+@pytest.mark.runner_setup(
+    env={"ELIS_URL": API_URL, "ELIS_USERNAME": USERNAME, "ELIS_PASSWORD": PASSWORD}
+)
+@pytest.mark.usefixtures("mock_login_request", "mock_get_schema")
+class TestDownload:
+    def test_stdout(self, cli_runner):
+        result = cli_runner.invoke(download_command, [schema_id])
+        assert not result.exit_code, print_tb(result.exc_info[2])
+        assert [] == json.loads(result.stdout)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,6 @@
 import json
 from copy import deepcopy
+from pathlib import Path
 from traceback import print_tb
 
 import pytest
@@ -212,7 +213,16 @@ schema_id = "1"
 )
 @pytest.mark.usefixtures("mock_login_request", "mock_get_schema")
 class TestDownload:
+    output_file = Path("test.json")
+
     def test_stdout(self, cli_runner):
         result = cli_runner.invoke(download_command, [schema_id])
         assert not result.exit_code, print_tb(result.exc_info[2])
         assert [] == json.loads(result.stdout)
+
+    def test_output_file(self, isolated_cli_runner):
+        result = isolated_cli_runner.invoke(
+            download_command, [schema_id, "-O", str(self.output_file)]
+        )
+        assert not result.exit_code, print_tb(result.exc_info[2])
+        assert [] == json.loads(self.output_file.read_text())


### PR DESCRIPTION
Should fix https://github.com/rossumai/elisctl/issues/32 but it needs to be tested on windows yet.