### PR TITLE
Allow elisctl schema transform add -h

### DIFF
--- a/elisctl/arguments.py
+++ b/elisctl/arguments.py
@@ -1,3 +1,19 @@
+import json
+
+import functools
+
 import click
+from typing import IO
 
 id_argument = click.argument("id_", metavar="ID", type=int)
+
+
+def schema_file_argument(command):
+    click.argument("schema_file", type=click.File("rb"))(command)
+
+    @functools.wraps(command)
+    def wrapped(ctx: click.Context, schema_file: IO[str], *args, **kwargs):
+        ctx.obj = {"SCHEMA": json.load(schema_file)}
+        return command(ctx, *args, **kwargs)
+
+    return wrapped

--- a/elisctl/schema/transform.py
+++ b/elisctl/schema/transform.py
@@ -6,6 +6,7 @@ from typing import List, Callable, Optional, IO, Tuple, Iterable, Dict, Union, S
 
 import click as click
 
+from elisctl import arguments
 from elisctl.lib import split_dict_params
 
 DataPointDictItem = Union[str, int, dict, None, list]
@@ -14,7 +15,6 @@ DataPointDict = Dict[str, DataPointDictItem]
 
 @click.group("transform", help="Transform schema file content.")
 @click.pass_context
-@click.argument("schema_file", type=click.File("rb"))
 @click.option(
     "--indent", default=2, type=int, show_default=True, help="Indentation of resulting JSON."
 )
@@ -22,14 +22,13 @@ DataPointDict = Dict[str, DataPointDictItem]
     "--ensure-ascii", is_flag=True, type=bool, help="Escape non-ASCII characters in resulting JSON."
 )
 @click.option("--sort-keys", is_flag=True, type=bool, help="Order keys in resulting JSON.")
-def cli(
-    ctx: click.Context, schema_file: IO[str], indent: int, ensure_ascii: bool, sort_keys: bool
-) -> None:
-    ctx.obj = {"SCHEMA": json.load(schema_file)}
+def cli(ctx: click.Context, indent: int, ensure_ascii: bool, sort_keys: bool) -> None:
+    pass
 
 
 @cli.command(name="substitute-options", help="Substitute options in existing enum datapoint.")
 @click.pass_context
+@arguments.schema_file_argument
 @click.argument("id_", metavar="ID", type=str)
 @click.argument("new_options", type=click.File("rb"))
 def substitute_options_command(ctx: click.Context, new_options: IO[str], id_: str) -> List[dict]:
@@ -39,6 +38,7 @@ def substitute_options_command(ctx: click.Context, new_options: IO[str], id_: st
 
 @cli.command(name="remove", help="Remove datapoints.")
 @click.pass_context
+@arguments.schema_file_argument
 @click.argument("ids", nargs=-1, type=str)
 def remove_command(ctx: click.Context, ids: Tuple[str, ...]) -> List[dict]:
     return traverse_datapoints(ctx.obj["SCHEMA"], remove, ids=ids)
@@ -50,6 +50,7 @@ def remove_command(ctx: click.Context, ids: Tuple[str, ...]) -> List[dict]:
     help="Put all datapoints into a multivalue (unless they are already in a multivalue).",
 )
 @click.pass_context
+@arguments.schema_file_argument
 @click.argument("exclude_ids", nargs=-1, type=str)
 def wrap_in_multivalue_command(ctx: click.Context, exclude_ids: Tuple[str, ...]) -> List[dict]:
     return traverse_datapoints(ctx.obj["SCHEMA"], wrap_in_multivalue, exclude_ids=set(exclude_ids))
@@ -65,6 +66,7 @@ DATAPOINT_PARAMETERS are expected as <key>=<value> pairs, where <value> can be a
 """,
 )
 @click.pass_context
+@arguments.schema_file_argument
 @click.argument("parent_id", type=str)
 @click.argument("datapoint_parameters", nargs=-1, type=str)
 @click.option(
@@ -105,6 +107,7 @@ DATAPOINT_PARAMETERS are expected as <key>=<value> pairs, where <value> can be a
 """,
 )
 @click.pass_context
+@arguments.schema_file_argument
 @click.argument("id_", metavar="ID", type=str)
 @click.argument("datapoint_parameters", nargs=-1, type=str)
 @click.option(
@@ -134,6 +137,7 @@ def change_command(
 
 @cli.command(name="move", help="Move datapoint to new parent datapoint.")
 @click.pass_context
+@arguments.schema_file_argument
 @click.argument("source_id", type=str)
 @click.argument("target_id", type=str)
 def move_command(ctx: click.Context, source_id: str, target_id: str) -> List[dict]:
@@ -145,12 +149,7 @@ def move_command(ctx: click.Context, source_id: str, target_id: str) -> List[dic
 @cli.resultcallback()
 @click.pass_context
 def process_result(
-    ctx: click.Context,
-    result: List[dict],
-    schema_file: IO[str],
-    indent: int,
-    ensure_ascii: bool,
-    sort_keys: bool,
+    ctx: click.Context, result: List[dict], indent: int, ensure_ascii: bool, sort_keys: bool
 ) -> None:
     click.echo(json.dumps(result, indent=indent, ensure_ascii=ensure_ascii, sort_keys=sort_keys))
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -70,7 +70,7 @@ class TestTransformSchema:
             json.dump(OPTIONS, options)
 
         result = isolated_cli_runner.invoke(
-            transform.cli, [SCHEMA_NAME, "substitute-options", "vat_rate", OPTIONS_NAME]
+            transform.cli, ["substitute-options", SCHEMA_NAME, "vat_rate", OPTIONS_NAME]
         )
         assert not result.exit_code
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -79,7 +79,7 @@ class TestTransformSchema:
 
     def test_change(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
-            transform.cli, [SCHEMA_NAME, "change", "vat_rate", f"options={json.dumps(OPTIONS)}"]
+            transform.cli, ["change", SCHEMA_NAME, "vat_rate", f"options={json.dumps(OPTIONS)}"]
         )
         assert not result.exit_code
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -89,7 +89,7 @@ class TestTransformSchema:
     def test_change_all_datapoints(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
             transform.cli,
-            [SCHEMA_NAME, "change", "ALL", "-c", "datapoint", 'constraints={"required":true}'],
+            ["change", SCHEMA_NAME, "ALL", "-c", "datapoint", 'constraints={"required":true}'],
         )
         assert not result.exit_code
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -101,7 +101,7 @@ class TestTransformSchema:
         with open(SCHEMA_NAME, "w") as schema:
             json.dump(ORIGINAL_SCHEMA, schema)
 
-        result = isolated_cli_runner.invoke(transform.cli, [SCHEMA_NAME, "remove", "vat_rate"])
+        result = isolated_cli_runner.invoke(transform.cli, ["remove", SCHEMA_NAME, "vat_rate"])
         assert not result.exit_code
         new_schema = deepcopy(ORIGINAL_SCHEMA)
         new_schema[0]["children"] = []
@@ -109,7 +109,7 @@ class TestTransformSchema:
 
     def test_move(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
-            transform.cli, [SCHEMA_NAME, "move", "vat_rate", "other"]
+            transform.cli, ["move", SCHEMA_NAME, "vat_rate", "other"]
         )
         assert not result.exit_code, print_tb(result.exc_info[2])
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -118,7 +118,7 @@ class TestTransformSchema:
 
     def test_add(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
-            transform.cli, [SCHEMA_NAME, "add", "basic_info", "id=test"]
+            transform.cli, ["add", SCHEMA_NAME, "basic_info", "id=test"]
         )
         assert not result.exit_code, print_tb(result.exc_info[2])
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -138,7 +138,7 @@ class TestTransformSchema:
 
     def test_add_place_before(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
-            transform.cli, [SCHEMA_NAME, "add", "other", "id=test", "--place-before", "desc"]
+            transform.cli, ["add", SCHEMA_NAME, "other", "id=test", "--place-before", "desc"]
         )
         assert not result.exit_code, print_tb(result.exc_info[2])
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -159,7 +159,7 @@ class TestTransformSchema:
 
     def test_add_single_to_empty_multivalue(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
-            transform.cli, [SCHEMA_NAME, "add", "test_multi", "id=test"]
+            transform.cli, ["add", SCHEMA_NAME, "test_multi", "id=test"]
         )
         assert not result.exit_code, print_tb(result.exc_info[2])
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -177,7 +177,7 @@ class TestTransformSchema:
 
     def test_wrap_in_multivalue(self, isolated_cli_runner):
         result = isolated_cli_runner.invoke(
-            transform.cli, [SCHEMA_NAME, "wrap-in-multivalue", "desc"]
+            transform.cli, ["wrap-in-multivalue", SCHEMA_NAME, "desc"]
         )
         assert not result.exit_code
         new_schema = deepcopy(ORIGINAL_SCHEMA)
@@ -193,6 +193,10 @@ class TestTransformSchema:
             }
         )
         assert new_schema == json.loads(result.stdout)
+
+    def test_help_without_args_in_parent(self, isolated_cli_runner):
+        result = isolated_cli_runner.invoke(transform.cli, ["add", "--help"])
+        assert not result.exit_code, print_tb(result.exc_info[2])
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes: https://github.com/rossumai/elisctl/issues/27

There are two options how to solve the above mentioned issue:
1. backward compatible where add will be called `elisctl schema transform FILE add ...`, or
2. backward **in**compatible where add will be called `elisctl schema transform add FILE ...`.

The latter is implemented in this PR as it is probably also more common way of using CLIs. The question is, which way we should go.