### PR TITLE
Enhancement/allow adding removing of queues of user

### DIFF
--- a/elisctl/lib/api_client.py
+++ b/elisctl/lib/api_client.py
@@ -240,11 +240,17 @@ class ELISClient(APIClient):
         return workspace
 
     def get_queues(
-        self, sideloads: Optional[Iterable[APIObject]] = None, *, workspace: Optional[int] = None
+        self,
+        sideloads: Optional[Iterable[APIObject]] = None,
+        *,
+        workspace: Optional[int] = None,
+        users: Optional[Iterable[int]] = None,
     ) -> List[dict]:
-        query = {}
+        query: Dict[str, Any] = {}
         if workspace:
             query[WORKSPACES.singular] = workspace
+        if users:
+            query[USERS.plural] = users
         queues_list, _ = self.get_paginated(QUEUES, query=query)
         self._sideload(queues_list, sideloads)
         return queues_list

--- a/elisctl/lib/api_client.py
+++ b/elisctl/lib/api_client.py
@@ -177,7 +177,9 @@ class APIClient(AbstractContextManager):
                     url = obj[sideload.singular]
                 except KeyError:
                     obj[sideload.plural] = [
-                        sideloaded_dicts.get(url, {}) for url in obj[sideload.plural]
+                        sideloaded_dicts[url]
+                        for url in obj[sideload.plural]
+                        if url in sideloaded_dicts
                     ]
                 else:
                     obj[sideload.singular] = sideloaded_dicts.get(url, {})

--- a/elisctl/main.py
+++ b/elisctl/main.py
@@ -14,6 +14,7 @@ from elisctl import (
     __version__,
     CTX_DEFAULT_PROFILE,
     CTX_PROFILE,
+    user_assignment,
 )
 
 
@@ -40,6 +41,7 @@ entry_point.add_command(tools.cli)
 entry_point.add_command(csv.cli)
 entry_point.add_command(elisctl.schema.commands.cli)
 entry_point.add_command(user.cli)
+entry_point.add_command(user_assignment.cli)
 entry_point.add_command(workspace.cli)
 entry_point.add_command(queue.cli)
 entry_point.add_command(document.cli)

--- a/elisctl/option.py
+++ b/elisctl/option.py
@@ -44,14 +44,30 @@ def workspace_id(command: Optional[Callable] = None, **kwargs):
     return decorator(command)
 
 
-queue = click.option(
-    "-q",
-    "--queue-id",
-    "queue_ids",
-    type=int,
-    multiple=True,
-    help="Queue IDs, which the user will be associated with.",
-)
+def queue(command: Optional[Callable] = None, **kwargs):
+    default_kwargs = {
+        "type": int,
+        "multiple": True,
+        "help": "Queue IDs, which the user will be associated with.",
+    }
+    kwargs = {**default_kwargs, **kwargs}
+    decorator = click.option("-q", "--queue-id", "queue_ids", **kwargs)
+    if command is None:
+        return decorator
+    return decorator(command)
+
+
+def user(command: Optional[Callable] = None, **kwargs):
+    default_kwargs = {
+        "type": int,
+        "multiple": True,
+        "help": "User IDs, which the queues will be associated with.",
+    }
+    kwargs = {**default_kwargs, **kwargs}
+    decorator = click.option("-u", "--user-id", "user_ids", **kwargs)
+    if command is None:
+        return decorator
+    return decorator(command)
 
 
 service_url = click.option(

--- a/elisctl/schema/commands.py
+++ b/elisctl/schema/commands.py
@@ -4,7 +4,7 @@ from typing import Optional, IO
 
 import click
 
-from elisctl import option
+from elisctl import option, argument
 from elisctl.lib.api_client import APIClient, get_json
 from . import upload
 from .xlsx import SchemaToXlsx
@@ -22,7 +22,7 @@ cli.add_command(upload.upload_command)
 
 @cli.command(name="get", help="Download schema from ELIS.")
 @click.pass_context
-@click.argument("id_", metavar="ID", type=str)
+@argument.id_(type=str)
 @click.option("--indent", default=2, type=int)
 @click.option("--ensure-ascii", is_flag=True, type=bool)
 @click.option("--format", "format_", default="json", type=click.Choice(["json", "xlsx"]))

--- a/elisctl/schema/upload.py
+++ b/elisctl/schema/upload.py
@@ -12,7 +12,7 @@ LoadFunction = Callable[[IO[bytes]], SchemaContent]
 
 
 @click.command(name="update")
-@click.argument("id_", metavar="ID", type=str)
+@argument.id_(type=str)
 @argument.schema_content
 @click.option("--rewrite", is_flag=True, type=bool)
 @click.option("--name", default=None, type=str)

--- a/elisctl/user.py
+++ b/elisctl/user.py
@@ -1,12 +1,11 @@
 from itertools import chain
-
-from typing import Tuple, Optional, Dict, Any
+from typing import Any, Dict, Optional, Tuple
 
 import click
 from tabulate import tabulate
 
 from elisctl import argument, option
-from elisctl.lib import QUEUES, GROUPS, USERS, generate_secret
+from elisctl.lib import GROUPS, QUEUES, USERS, generate_secret
 from elisctl.lib.api_client import ELISClient
 
 

--- a/elisctl/user_assignment.py
+++ b/elisctl/user_assignment.py
@@ -1,0 +1,46 @@
+from itertools import chain
+
+from tabulate import tabulate
+from typing import Tuple, Optional, List, Dict
+
+import click
+from elisctl import option
+from elisctl.lib import USERS
+from elisctl.lib.api_client import ELISClient
+
+
+@click.group("user_assignment")
+def cli() -> None:
+    """Assignment of users to queues"""
+    pass  # pragma: no cover
+
+
+@cli.command(name="list")
+@option.user(required=False, help="User IDs, which the queues will be filtered by.")
+@option.queue(required=False, help="Queue IDs, which the users will be filtered by.")
+@click.pass_context
+def list_command(ctx: click.Context, user_ids: Tuple[int], queue_ids: Tuple[int]) -> None:
+    """List all users and their assignments to queues."""
+    with ELISClient(context=ctx.obj) as elis:
+        queue_users = elis.get_queues((USERS,), users=user_ids)
+
+    user_queues: Dict[int, List[List[Optional[str]]]] = {}
+    for queue in queue_users:
+        if queue_ids and int(queue["id"]) not in queue_ids:
+            continue
+        for user in queue["users"]:
+            user_id = int(user["id"])
+            if user_ids and user_id not in user_ids:
+                continue
+
+            if user_id not in user_queues:
+                user_queues[user_id] = [[user["id"], user["username"], queue["id"], queue["name"]]]
+            else:
+                user_queues[user_id].append([None, None, queue["id"], queue["name"]])
+    user_queues = dict(sorted(user_queues.items()))
+    click.echo(
+        tabulate(
+            chain.from_iterable(user_queues.values()),
+            headers=["id", "username", "queue id", "queue name"],
+        )
+    )

--- a/elisctl/user_assignment.py
+++ b/elisctl/user_assignment.py
@@ -5,7 +5,7 @@ from typing import Tuple, Optional, List, Dict
 
 import click
 from elisctl import option
-from elisctl.lib import USERS
+from elisctl.lib import USERS, QUEUES
 from elisctl.lib.api_client import ELISClient
 
 
@@ -44,3 +44,15 @@ def list_command(ctx: click.Context, user_ids: Tuple[int], queue_ids: Tuple[int]
             headers=["id", "username", "queue id", "queue name"],
         )
     )
+
+
+@cli.command(name="add", help="Add user to queues.")
+@option.user
+@option.queue
+@click.pass_context
+def add_command(ctx: click.Context, user_ids: Tuple[int], queue_ids: Tuple[int]) -> None:
+    with ELISClient(context=ctx.obj) as elis:
+        for user_id in user_ids:
+            user = elis.get_user(user_id)
+            new_queues = user["queues"] + [elis.get_queue(q_id)["url"] for q_id in queue_ids]
+            elis.patch(f"{USERS}/{user_id}", {str(QUEUES): new_queues})

--- a/elisctl/user_assignment.py
+++ b/elisctl/user_assignment.py
@@ -56,3 +56,15 @@ def add_command(ctx: click.Context, user_ids: Tuple[int], queue_ids: Tuple[int])
             user = elis.get_user(user_id)
             new_queues = user["queues"] + [elis.get_queue(q_id)["url"] for q_id in queue_ids]
             elis.patch(f"{USERS}/{user_id}", {str(QUEUES): new_queues})
+
+
+@cli.command(name="remove", help="Remove user from queues.")
+@option.user
+@option.queue
+@click.pass_context
+def remove_command(ctx: click.Context, user_ids: Tuple[int], queue_ids: Tuple[int]) -> None:
+    with ELISClient(context=ctx.obj) as elis:
+        for user_id in user_ids:
+            queues = elis.get_queues(users=[user_id])
+            new_queues = [q["url"] for q in queues if int(q["id"]) not in queue_ids]
+            elis.patch(f"{USERS}/{user_id}", {str(QUEUES): new_queues})

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -9,17 +9,17 @@ from itertools import chain
 from requests import Request
 from requests_mock.response import _Context
 
-from elisctl.user import list_command, change_command, delete_command, create_command
+from elisctl.user import change_command, create_command, delete_command, list_command
 from tests import SuperDictOf
 from tests.conftest import (
     API_URL,
-    TOKEN,
-    match_uploaded_json,
-    ORGANIZATIONS_URL,
-    WORKSPACES_URL,
-    QUEUES_URL,
     GROUPS_URL,
+    ORGANIZATIONS_URL,
+    QUEUES_URL,
+    TOKEN,
     USERS_URL,
+    WORKSPACES_URL,
+    match_uploaded_json,
 )
 
 USERNAME = "test_user@rossum.ai"

--- a/tests/test_user_assignment.py
+++ b/tests/test_user_assignment.py
@@ -1,0 +1,94 @@
+from traceback import print_tb
+
+import pytest
+
+from elisctl.user_assignment import list_command
+from tests.conftest import USERS_URL, QUEUES_URL, API_URL
+
+USERNAME = "test_user@rossum.ai"
+PASSWORD = "secret"
+
+
+@pytest.mark.runner_setup(
+    env={"ELIS_URL": API_URL, "ELIS_USERNAME": USERNAME, "ELIS_PASSWORD": PASSWORD}
+)
+@pytest.mark.usefixtures("mock_login_request")
+class TestList:
+    queue_ids = ["1", "2"]
+    name = "TestQueue"
+    user_ids = ["5", "4"]
+    user_urls = [f"{USERS_URL}/{id_}" for id_ in user_ids]
+    queue_urls = [f"{QUEUES_URL}/{id_}" for id_ in queue_ids]
+
+    @pytest.fixture
+    def urls(self, requests_mock):
+        requests_mock.get(
+            f"{QUEUES_URL}",
+            json={
+                "pagination": {"total": 2, "next": None},
+                "results": [
+                    {"id": id_, "url": url, "name": self.name, "users": self.user_urls}
+                    for id_, url in zip(self.queue_ids, self.queue_urls)
+                ],
+            },
+        )
+
+        requests_mock.get(
+            USERS_URL,
+            json={
+                "pagination": {"total": 2, "next": None},
+                "results": [
+                    {"id": id_, "url": url, "username": f"user_{id_}"}
+                    for id_, url in zip(self.user_ids, self.user_urls)
+                ],
+            },
+        )
+
+    @pytest.mark.usefixtures("urls")
+    def test_no_filter(self, cli_runner):
+        result = cli_runner.invoke(list_command)
+        assert not result.exit_code, print_tb(result.exc_info[2])
+        expected_table = f"""\
+  id  username      queue id  queue name
+----  ----------  ----------  ------------
+   {self.user_ids[1]}  user_{self.user_ids[1]}               {self.queue_ids[0]}  {self.name}
+                           {self.queue_ids[1]}  {self.name}
+   {self.user_ids[0]}  user_{self.user_ids[0]}               {self.queue_ids[0]}  {self.name}
+                           {self.queue_ids[1]}  {self.name}
+"""
+        assert result.output == expected_table
+
+    @pytest.mark.usefixtures("urls")
+    def test_queue_filter(self, cli_runner):
+        result = cli_runner.invoke(list_command, ["-q", self.queue_ids[0]])
+        assert not result.exit_code, print_tb(result.exc_info[2])
+        expected_table = f"""\
+  id  username      queue id  queue name
+----  ----------  ----------  ------------
+   {self.user_ids[1]}  user_{self.user_ids[1]}               {self.queue_ids[0]}  {self.name}
+   {self.user_ids[0]}  user_{self.user_ids[0]}               {self.queue_ids[0]}  {self.name}
+"""
+        assert result.output == expected_table
+
+    @pytest.mark.usefixtures("urls")
+    def test_user_filter(self, cli_runner):
+        result = cli_runner.invoke(list_command, ["-u", self.user_ids[0]])
+        assert not result.exit_code, print_tb(result.exc_info[2])
+        expected_table = f"""\
+  id  username      queue id  queue name
+----  ----------  ----------  ------------
+   {self.user_ids[0]}  user_{self.user_ids[0]}               {self.queue_ids[0]}  {self.name}
+                           {self.queue_ids[1]}  {self.name}
+"""
+        assert result.output == expected_table
+
+    @pytest.mark.usefixtures("urls")
+    def test_queue_user_filter(self, cli_runner):
+        result = cli_runner.invoke(list_command, ["-u", self.user_ids[0], "-q", self.queue_ids[0]])
+        assert not result.exit_code, print_tb(result.exc_info[2])
+        expected_table = f"""\
+  id  username      queue id  queue name
+----  ----------  ----------  ------------
+   {self.user_ids[0]}  user_{self.user_ids[0]}               {self.queue_ids[0]}  {self.name}
+"""
+        assert result.output == expected_table


### PR DESCRIPTION
A subcommand `user_assignment` on the top level was created, which modifies the queues:users relationship. It allows for assignments/removals of:
1. N users to 1 queue (`elisctl user_assignment <action> -q 1 -u 1 -u 2`),
2. 1 user to N queues (`elisctl user_assignment <action> -q 1  -q 2 -u 1`),
3. 1 user to 1 queue (`elisctl user_assignment <action> -q 1 -u 1`), as well as
4. M user to N queues (`elisctl user_assignment <action> -q 1  -q 2 -u 1 -u 2 -u 3`).

If the user does (in case of assignment) have the queue, nothing happens.
If the user does not (in case of removal) has not the queue, nothing happens.

Also a `elisctl user_assignment list` command was added, which lists assignments of queues to users. Filters can be applied.

Closes: https://github.com/rossumai/elisctl/issues/82, https://github.com/rossumai/elisctl/issues/77