### PR TITLE
Fix python3.8 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 19.3b0
     hooks:
       - id: black
-        language_version: python3.7
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
@@ -20,9 +19,6 @@ repos:
       - id: bandit
         args: [-lll]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.701
+    rev: v0.770
     hooks:
       - id: mypy
-        # mypy v0.701 fails to build on python3.8 https://github.com/python/typed_ast/issues/124
-        # FIXME: remove language version with mypy v0.761
-        language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ jobs:
       env: TOXENV=linting TOXCFG=tox.ini
       stage: test
 
+    - python: 3.8
+      env: TOXENV=py38 TOXCFG=tox.ini
+      stage: test
+
     - python: 3.7
       env: TOXENV=py37 TOXCFG=tox.ini
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ jobs:
       env: TOXENV=py36 TOXCFG=tox.ini
       stage: test
 
-    - python: 3.7-dev
-      env: TOXENV=py37-dev TOXCFG=tox.ini
-      stage: test
-
     - stage: deploy
       python: 3.7
       install:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,4 +7,4 @@ class TestEntryPoint:
     def test_shell(self, cli_runner):
         result = cli_runner.invoke(entry_point)
         assert not result.exit_code, print_tb(result.exc_info[2])
-        assert "elis> " == result.output
+        assert result.output.rstrip("\n").endswith("elis> ")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -85,7 +85,7 @@ class TestCreate:
     def test_queues_not_specified(self, cli_runner):
         result = cli_runner.invoke(create_command, [NEW_USERNAME])
         assert result.exit_code == 2
-        assert 'Error: Missing option "-q" / "--queue-id".' in result.output
+        assert 'Error: Missing option "-q" / "--queue-id".' in result.output.replace("'", '"')
 
     @pytest.mark.usefixtures("mock_user_urls")
     def test_create_in_organization(self, requests_mock, cli_runner):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py37-dev, linting
+envlist = py36, py37, py38, linting
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py37-dev, linting
+envlist = py36, py37, py38, py37-dev, linting
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
having python3.8 interpreter, I was unable to run pre-commit properly. This is possible now.

- [x] I am just wondering whether I have done changes in `tox` related stuff properly (most likely not)