### PR TITLE
Fix `webhook change` command

### DIFF
--- a/elisctl/webhook.py
+++ b/elisctl/webhook.py
@@ -127,7 +127,7 @@ def change_command(
         if active is not None:
             data["active"] = active
         if events:
-            data["events"] = [events]
+            data["events"] = list(events)
         if config_url is not None:
             data["config"].update({"url": config_url})
         if config_secret is not None:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -203,7 +203,7 @@ class TestChange:
                 {
                     "queues": [f"{QUEUES_URL}/{QUEUE_ID}"],
                     "name": self.new_webhook_name,
-                    "events": [[self.new_event]],
+                    "events": [self.new_event],
                     "active": True,
                     "config": {"url": CONFIG_URL, "secret": CONFIG_SECRET, "insecure_ssl": False},
                 },


### PR DESCRIPTION
Webhook `change` command did not properly handled event parameter, this is being fixed with this PR